### PR TITLE
 Fixed MCU to Nano ethernet by forcing speed to 10Mbps.

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -540,7 +540,7 @@
                     reg = <0x0>;
                     label = "mcu";
                     fixed-link {
-                        speed = <100>;
+                        speed = <10>;
                         full-duplex;
                     };
                 };


### PR DESCRIPTION
The kernel DTS file is modified so that the ethernet connection between the Nano and the MCU is forced to 10Mbps.  This is a workaround allowing the connection to work.  The connection should be capable of 100Mbps and needs more investigation.