### PR TITLE
Fixes the switch to MCU ethernet to work at 100Mbps.

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -545,7 +545,7 @@
                     reg = <0x0>;
                     label = "mcu";
                     fixed-link {
-                        speed = <10>;
+                        speed = <100>;
                         full-duplex;
                     };
                 };


### PR DESCRIPTION
This is the Nano kernel side fix for Jira issue HW-2258 and HW-2268.  There is a corresponding MCU fix that is required for the ethernet connection to work at 100Mbps.  

The device tree file forces the Marvell switch's port0 to 100Mbp allowing the ethernet connection to the MCU to work.
