### PR TITLE
Fix the serial port transmit/recieve failure

### DIFF
--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -964,6 +964,9 @@ static void sc16is7xx_set_termios(struct uart_port *port,
 	sc16is7xx_port_write(port, SC16IS7XX_EFR_REG, flow);
 	regcache_cache_bypass(s->regmap, false);
 
+	/* Inform the base serial core that this device provides Auto CTS, RTS, and XON/XOFF */
+	port->status |= UPSTAT_AUTOCTS | UPSTAT_AUTORTS | UPSTAT_AUTOXOFF;
+
 	/* Update LCR register */
 	sc16is7xx_port_write(port, SC16IS7XX_LCR_REG, lcr);
 


### PR DESCRIPTION
The linux kernel was controlling the RTS and CTS lines and disabling the
interrupts based on the values. However this chip supports Auto RTS,
CTS, and XON. The auto mode and linux manual mode were conflicting
putting the chip in to a bad state.