### PR TITLE
Adds gpio-hog on the cell-dtr line

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -461,6 +461,7 @@
 
         cell-dtr {
             status = "okay";
+            gpio-hog;
             output-low;
             gpios = <TEGRA_GPIO(Z, 0) GPIO_ACTIVE_HIGH>;
             line-name = "CELL-DTR";


### PR DESCRIPTION
I've had this patch sitting for a while. It makes sure that this cell sleep line is in the kernel sys debug output in the off chance that we ever want to use it.