### PR TITLE
Fixed issue with the 9190 micrel phy

### DIFF
--- a/drivers/net/phy/micrel.c
+++ b/drivers/net/phy/micrel.c
@@ -1002,6 +1002,7 @@ static struct phy_driver ksphy_driver[] = {
 	.driver_data	= &ksz9021_type,
 	.probe		= kszphy_probe,
 	.config_init	= ksz9031_config_init,
+	.config_aneg	= genphy_config_aneg,
 	.read_status	= ksz9031_read_status,
 	.ack_interrupt	= kszphy_ack_interrupt,
 	.config_intr	= kszphy_config_intr,

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -45,11 +45,6 @@
         };
     };
 
-    // Disable the ethernet controller
-    ether_qos@2490000 {
-        status = "disabled";
-    };
-
     // Disable the framebuffer memory reserve
     reserved-memory {
         fb0_reserved: fb0_carveout {
@@ -200,6 +195,24 @@
             nvidia,rx-clk-tap-delay = <6>;
         };
     };
+
+    ether_qos@2490000 {
+            mdio {
+                status = "okay";
+                phy0: ethernet-phy@0 {
+                    status = "okay";
+                    device_type = "ethernet-phy";
+                    micrel,copper-mode;
+                    micrel,reg-init = <2 8 0xfc1f 0x03e0>;
+                    rxc-skew-ps = <3000>;
+                    rxdv-skew-ps = <0>;
+                    txc-skew-ps = <3000>;
+                    txen-skew-ps = <0>;
+                };
+            };
+    };
+
+
     //*********************************************************************
     // GPIO Input Buttons, configured to trigger keyboard events.
     //*********************************************************************
@@ -327,7 +340,6 @@
             gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(P, 6) GPIO_ACTIVE_HIGH>;
             line-name = "TPM_IRQ";
         };
-
 
         /////////////////////////////////////
         // LCD

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -11,6 +11,8 @@
  * more details.
  */
 #include "common/tegra194-p2888-0001-p2822-0000-common.dtsi"
+#include "common/tegra194-p2822-camera-modules.dtsi"
+#include "t19x-common-modules/tegra194-camera-plugin-manager.dtsi"
 #include <dt-bindings/gpio/tegra194-gpio.h>
 
 / {
@@ -162,7 +164,7 @@
 
         // The PINMUX needed to be adjusted to put the CS line as a GPIO pin which is software controlled,
         // the hardware control was dropping the CS line between transactions resetting the TPM.
-        cs-gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Z,6) GPIO_ACTIVE_HIGH>;
+           cs-gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Z,6) GPIO_ACTIVE_HIGH>;
 
         spi@0 {
             reg = <0x0>;
@@ -195,19 +197,19 @@
     };
 
     ether_qos@2490000 {
-            mdio {
+        mdio {
+            status = "okay";
+            phy0: ethernet-phy@0 {
                 status = "okay";
-                phy0: ethernet-phy@0 {
-                    status = "okay";
-                    device_type = "ethernet-phy";
-                    micrel,copper-mode;
-                    micrel,reg-init = <2 8 0xfc1f 0x03e0>;
-                    rxc-skew-ps = <3000>;
-                    rxdv-skew-ps = <0>;
-                    txc-skew-ps = <3000>;
-                    txen-skew-ps = <0>;
-                };
+                device_type = "ethernet-phy";
+                micrel,copper-mode;
+                micrel,reg-init = <2 8 0xfc1f 0x03e0>;
+                rxc-skew-ps = <3000>;
+                rxdv-skew-ps = <0>;
+                txc-skew-ps = <3000>;
+                txen-skew-ps = <0>;
             };
+        };
     };
 
 
@@ -255,34 +257,10 @@
         };
     };
 
-    // Deletes some nodes that we aren't using
-#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
-	xusb_padctl@3520000 {
-		ports {
-            /delete-node/ usb2-3;
-        };
-    };
-#endif
-
-	plugin-manager {
-        /delete-node/ usb-vbus-en0-gpio-value;
-    };
-
-    fixed-regulators {
-        /delete-node/ regulator@107;
-        /delete-node/ regulator@114;
-    };
-
     //*********************************************************************
     // GPIO Setup
     //*********************************************************************
-    gpio@2200000 {
-        /////////////////////////////////////
-        // Delete unneeded GPIOs
-        /////////////////////////////////////
-        /delete-node/ pcie-reg-enable;
-        /delete-node/ wifi-enable;
-
+    gpio: gpio@02200000 {
         /////////////////////////////////////
         // Input Power good
         /////////////////////////////////////
@@ -290,8 +268,7 @@
         ctm_pwr_good {
             status = "okay";
             input;
-            gpio-hog;
-            gpios = <TEGRA194_MAIN_GPIO(N, 0) GPIO_ACTIVE_HIGH>;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(N, 0) GPIO_ACTIVE_HIGH>;
             line-name = "CTM_PWR_GOOD";
         };
 
@@ -302,8 +279,7 @@
         overtemp_shdn {
             status = "okay";
             input;
-            gpio-hog;
-            gpios = <TEGRA194_MAIN_GPIO(Z, 2) GPIO_ACTIVE_HIGH>;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Z, 2) GPIO_ACTIVE_HIGH>;
             line-name = "OVERTEMP_SHDN";
         };
 
@@ -316,16 +292,23 @@
             status = "okay";
             gpio-hog;
             output-low;
-            gpios = <TEGRA194_MAIN_GPIO(Z, 1) GPIO_ACTIVE_HIGH>;
-            line-name = "USB0_ENABLEn";
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Z, 1) GPIO_ACTIVE_HIGH>;
+            line-name = "USB0_ENABLE";
+        };
+
+        //USB_VBUS_DET => GPIO10 => CAN1_WAKE => GPIO3 P(BB,2) *
+        usb0_vbus_detect {
+            status = "okay";
+            input;
+            gpios = <&tegra_main_gpio TEGRA194_AON_GPIO(BB, 2) GPIO_ACTIVE_HIGH>;
+            line-name = "USB0_VBUS_DETECT";
         };
 
         //USB_ID => GPIO30 => GPIO20 => GPIO3 P(Q,0) *
         usb0_id {
             status = "okay";
             input;
-            gpio-hog;
-            gpios = <TEGRA194_MAIN_GPIO(Q, 0) GPIO_ACTIVE_HIGH>;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Q, 0) GPIO_ACTIVE_HIGH>;
             line-name = "USB0_ID";
         };
 
@@ -336,9 +319,8 @@
         pm_led_bl_st {
             status = "okay";
             input;
-            gpio-hog;
-            gpios = <TEGRA194_MAIN_GPIO(P, 4) GPIO_ACTIVE_HIGH>;
-            line-name = "PM_LED_BL_ST";
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(P, 4) GPIO_ACTIVE_HIGH>;
+            line-name = "PM_LED_LB_ST";
         };
 
         // TPM_RSTn => GPIO24 => DP_AUX_CH3_HPD => GPIO3 P(M,3) *
@@ -346,16 +328,16 @@
             status = "okay";
             gpio-hog;
             output-low;
-            gpios = <TEGRA194_MAIN_GPIO(M, 3) GPIO_ACTIVE_HIGH>;
-            line-name = "TPM_RSTn";
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(M, 3) GPIO_ACTIVE_HIGH>;
+            line-name = "TPM_RST";
         };
 
         // TPM_IRQn => GPIO34 => SOC_GPIO06 => GPIO3 P(P,6) *
         tpm_irq {
             status = "okay";
             gpio-hog;
-            input;
-            gpios = <TEGRA194_MAIN_GPIO(P, 6) GPIO_ACTIVE_HIGH>;
+            output-low;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(P, 6) GPIO_ACTIVE_HIGH>;
             line-name = "TPM_IRQ";
         };
 
@@ -367,7 +349,7 @@
             status = "okay";
             gpio-hog;
             output-high;
-            gpios = <TEGRA194_MAIN_GPIO(M, 6) GPIO_ACTIVE_HIGH>;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(M, 6) GPIO_ACTIVE_HIGH>;
             line-name = "LCD_RESET";
         };
          //LCD_D_C => GPIO31 => SAFE_STATE  => GPIO3 P(EE,0)
@@ -375,19 +357,8 @@
             status = "okay";
             gpio-hog;
             output-high;
-            gpios = <TEGRA194_MAIN_GPIO(E, 0) GPIO_ACTIVE_HIGH>;
+            gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(E, 0) GPIO_ACTIVE_HIGH>;
             line-name = "LCD_D_C";
-        };
-    };
-
-    gpio@c2f0000 {
-        //USB_VBUS_DET => GPIO10 => CAN1_WAKE => GPIO3 P(BB,2) *
-        usb0_vbus_detect {
-            status = "okay";
-            input;
-            gpio-hog;
-            gpios = <TEGRA194_AON_GPIO(BB, 2) GPIO_ACTIVE_HIGH>;
-            line-name = "USB0_VBUS_DETECTn";
         };
     };
 


### PR DESCRIPTION
This fixes an issue with the ksz9131 driver, the config_aneg function was missing in the definition. Also a couple properties had to change from the default marvel to micrel along with some timing settings.