### PR TITLE
Fixes issue with dcm ethernet phy

### DIFF
--- a/drivers/net/phy/micrel.c
+++ b/drivers/net/phy/micrel.c
@@ -1002,6 +1002,7 @@ static struct phy_driver ksphy_driver[] = {
 	.driver_data	= &ksz9021_type,
 	.probe		= kszphy_probe,
 	.config_init	= ksz9031_config_init,
+	.config_aneg	= genphy_config_aneg,
 	.read_status	= ksz9031_read_status,
 	.ack_interrupt	= kszphy_ack_interrupt,
 	.config_intr	= kszphy_config_intr,

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -43,9 +43,21 @@
         };
     };
 
-    // Disable the ethernet controller
+    // Setup the phy to use micrel settings
     ether_qos@2490000 {
-        status = "disabled";
+        mdio {
+            status = "okay";
+            phy0: ethernet-phy@0 {
+                status = "okay";
+                device_type = "ethernet-phy";
+                micrel,copper-mode;
+                micrel,reg-init = <2 8 0xfc1f 0x03e0>;
+                rxc-skew-ps = <3000>;
+                rxdv-skew-ps = <0>;
+                txc-skew-ps = <3000>;
+                txen-skew-ps = <0>;
+            };
+        };
     };
 
     // Disable the framebuffer memory reserve


### PR DESCRIPTION
Fixes bug in the micrel driver for the KSZ9131 where config_aneg function pointer was missing causing a crash.
Also changes properties to micrel and adds some timing values. 

Sorry I screwed something up with the merge, hence the second pull request.