### PR TITLE
Fixes the reset, should be high

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -344,7 +344,7 @@
         tpm_rst {
             status = "okay";
             gpio-hog;
-            output-low;
+            output-high;
             gpios = <TEGRA194_MAIN_GPIO(M, 3) GPIO_ACTIVE_HIGH>;
             line-name = "TPM_RSTn";
         };


### PR DESCRIPTION
Switching this to High the tpm shows up under /dev/tpm0

So close.