### PR TITLE
Fixed issue with CTM -> DCM ethernet.

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -370,14 +370,6 @@
             gpios = <TEGRA194_MAIN_GPIO(M, 6) GPIO_ACTIVE_HIGH>;
             line-name = "LCD_RESET";
         };
-         //LCD_D_C => GPIO31 => SAFE_STATE  => GPIO3 P(EE,0)
-        lcd_d_c {
-            status = "okay";
-            gpio-hog;
-            output-high;
-            gpios = <TEGRA194_MAIN_GPIO(E, 0) GPIO_ACTIVE_HIGH>;
-            line-name = "LCD_D_C";
-        };
     };
 
     gpio@c2f0000 {


### PR DESCRIPTION
Found the issue with the ethernet not working between DCM and CTM. 

As the comment says it should have been connected to EE0 not E0. 

Guess what E0 is hooked to ==> RGMII_TXC

For now I have just removed it as I don't think we need it anyway and can be re-added when we look at the LCD. 