### PR TITLE
Fixed the i2c address

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -127,7 +127,7 @@
     //		LM75 Temperature      0x48 (Ethernet Switch)
     //		LM75 Temperature      0x49 (+53 Power Module)
     //		MAX6650 AUX Fan       0x1F (Aux Fan)
-    i2c@03160000 {
+    i2c@3160000 {
          status = "okay";
 
         lm75@48 {


### PR DESCRIPTION
The address for i2c-0 which has the temp and fan devices was wrong. 