### PR TITLE
Sets SIM detection lines as active high

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -321,7 +321,7 @@
             status = "okay";
             gpio-hog;
             input;
-            gpios = <TEGRA_GPIO(T, 0) GPIO_ACTIVE_LOW>;
+            gpios = <TEGRA_GPIO(T, 0) GPIO_ACTIVE_HIGH>;
             line-name = "SIMCARD1-PRESENTn";
         };
 
@@ -329,7 +329,7 @@
             status = "okay";
             gpio-hog;
             input;
-            gpios = <TEGRA_GPIO(S, 1) GPIO_ACTIVE_LOW>;
+            gpios = <TEGRA_GPIO(S, 1) GPIO_ACTIVE_HIGH>;
             line-name = "SIMCARD2-PRESENTn";
         };
 


### PR DESCRIPTION
The active low definition isn't doing what we expect, so we're changing
these GPIOs in the DTS to active high.

I've tested this change on a CTM, and it's allowed some more of the tests to pass, and the sim behaviour is more consistent now. I don't know why this was working fine on my CTM, but not on Matt Heffernan's but that'll remain a mystery for now.