### PR TITLE
Mloder 2020 08 26 backlight control

### DIFF
--- a/drivers/video/backlight/pwm_bl.c
+++ b/drivers/video/backlight/pwm_bl.c
@@ -90,7 +90,7 @@ static int pwm_backlight_update_status(struct backlight_device *bl)
 		brightness = 0;
 
 	if (pb->notify)
-		brightness = pb->notify(pb->dev, brightness);
+		pb->notify(pb->dev, brightness);
 
 	if (brightness > 0) {
 		duty_cycle = compute_duty_cycle(pb, brightness);

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -217,9 +217,13 @@
     /delete-node/ bluedroid_pm;
 
     backlight: backlight {
-        compatible = "gpio-backlight";
-        gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(N, 1) GPIO_ACTIVE_HIGH>;
-        default-on;
+        status = "okay";
+        compatible = "pwm-backlight";
+        pwm-gpio = <&tegra_main_gpio TEGRA194_MAIN_GPIO(N, 1) GPIO_ACTIVE_HIGH>;
+        pwms = <&tegra_pwm1 0 40161>;
+        power-supply = <&battery_reg>;
+        max-brightness = <255>;
+        default-brightness = <255>;
     };
 
     // Xavier Module SPI 2 --> Tegra SPI 2 (LCD, )


### PR DESCRIPTION
Fixed a bug with the new NVidia changes to the backlight code causing the brightness to be turned off
Updated the DTS to have PWM based backlight control