### PR TITLE
Fixes mmc and fb-reserve errors on boot of the DCM

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -65,6 +65,16 @@
         fb0_reserved: fb0_carveout {
             status = "disabled";
         };
+        fb1_reserved: fb1_carveout {
+            status = "disabled";
+        };
+        fb2_reserved: fb2_carveout {
+            status = "disabled";
+        };
+        fb3_reserved: fb3_carveout {
+            status = "disabled";
+        };
+
     };
 
     tegra_cec@3960000 {
@@ -92,6 +102,10 @@
     i2c@31c0000 {
         status = "disabled";
     };
+
+    sdhci@3400000 {
+	    status = "disabled";
+	};
 
     //*********************************************************************
     // Serial UART Setup

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -74,7 +74,6 @@
         fb3_reserved: fb3_carveout {
             status = "disabled";
         };
-
     };
 
     tegra_cec@3960000 {
@@ -104,8 +103,8 @@
     };
 
     sdhci@3400000 {
-	    status = "disabled";
-	};
+        status = "disabled";
+    };
 
     //*********************************************************************
     // Serial UART Setup


### PR DESCRIPTION
The fixes the following errors:


 6.006424] mmc1: CMD CRC or end bit error, int mask 0xc0000
[    6.007084] mmc1: CMD CRC or end bit error, int mask 0x40000
[    6.007678] mmc1: CMD CRC or end bit error, int mask 0x40000
[    6.008280] mmc1: CMD CRC or end bit error, int mask 0x40000
[    6.008881] mmc1: CMD CRC or end bit error, int mask 0x40000
[    6.009510] mmc1: CMD CRC or end bit error, int mask 0xc0000
[    6.010118] mmc1: CMD CRC or end bit error, int mask 0xc0000
[    6.010737] mmc1: CMD CRC or end bit error, int mask 0xc0000
[    6.011353] mmc1: CMD CRC or end bit error, int mask 0xc0000
[    6.012020] mmc1: CMD CRC or end bit error, int mask 0x40000

and

 
 0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb1_carveout': base 0x0000000000000000, size 0 MiB
[    0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb1_carveout': base 0x0000000000000000, size 0 MiB
[    0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb2_carveout': base 0x0000000000000000, size 0 MiB
[    0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb2_carveout': base 0x0000000000000000, size 0 MiB
[    0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb3_carveout': base 0x0000000000000000, size 0 MiB
[    0.000000] OF: fdt:Reserved memory: failed to reserve memory for node 'fb3_carveout': base 0x0000000000000000, size 0 MiB