### PR TITLE
Fixed address of serial device

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -110,7 +110,7 @@
     // Serial UART Setup
     //*********************************************************************
     // Xavier Module UART 3 -->  UART 1 (Debug Port)
-    serial@0c280000 {
+    serial@c280000 {
         compatible = "nvidia,tegra210-uart", "nvidia,tegra114-hsuart", "nvidia,tegra20-uart";
         console-port;
         sqa-automation-port;


### PR DESCRIPTION
Fixes the address of the serial device in the DCM device tree.