### PR TITLE
Apply perf fix upstream

### DIFF
--- a/tools/perf/util/srcline.c
+++ b/tools/perf/util/srcline.c
@@ -86,16 +86,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
 	bfd_vma pc, vma;
 	bfd_size_type size;
 	struct a2l_data *a2l = data;
+	flagword flags;
 
 	if (a2l->found)
 		return;
 
-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
+#ifdef bfd_get_section_flags
+	flags = bfd_get_section_flags(abfd, section);
+#else
+	flags = bfd_section_flags(section);
+#endif
+	if ((flags & SEC_ALLOC) == 0)
 		return;
 
 	pc = a2l->addr;
+#ifdef bfd_get_section_vma
 	vma = bfd_get_section_vma(abfd, section);
+#else
+	vma = bfd_section_vma(section);
+#endif
+#ifdef bfd_get_section_size
 	size = bfd_get_section_size(section);
+#else
+	size = bfd_section_size(section);
+#endif
 
 	if (pc < vma || pc >= vma + size)
 		return;


### PR DESCRIPTION
Pulled from mainline 0ada120c883d4f1f6aafd01cf0fbb10d8bbba015

This was being patched into the Yocto build, but that was causing
some annoying side effects with commits showing up in branches
when using devtool.

Original commit message:

Author: Changbin Du <changbin.du@gmail.com>
Date:   Tue Jan 28 23:29:38 2020 +0800

    perf: Make perf able to build with latest libbfd

    libbfd has changed the bfd_section_* macros to inline functions
    bfd_section_<field> since 2019-09-18. See below two commits:
      o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
      o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html

    This fix make perf able to build with both old and new libbfd.

    Signed-off-by: Changbin Du <changbin.du@gmail.com>
    Acked-by: Jiri Olsa <jolsa@redhat.com>
    Cc: Peter Zijlstra <peterz@infradead.org>
    Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
    Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>