### PR TITLE
Adds BACKUP_PFI gpio to CTM DTS

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -333,6 +333,16 @@
             line-name = "SIMCARD2-PRESENTn";
         };
 
+        // Indicates that system power has been lost.
+        // PFI stands for power fault indicator.
+        backup-pfi {
+            status = "okay";
+            input;
+            gpio-hog;
+            gpios = <TEGRA_GPIO(CC, 0) GPIO_ACTIVE_HIGH>;
+            line-name = "BACKUP_PFI";
+        };
+
         usb2-overcurrent {
             status = "okay";
             input;
@@ -409,14 +419,6 @@
             output-high;
             gpios = <TEGRA_GPIO(CC, 6) GPIO_ACTIVE_HIGH>;
             line-name = "USB2-VBUS-EN";
-        };
-
-        testpoint-50 {
-            status = "okay";
-            gpio-hog;
-            output-low;
-            gpios = <TEGRA_GPIO(CC, 0) GPIO_ACTIVE_HIGH>;
-            line-name = "TESTPOINT-50";
         };
 
         testpoint-51 {


### PR DESCRIPTION
This gpio indicates that system power has been lost. The test point
that it replaces doesn't exist in the P2 CTM Schematic.

On P1 hardware, this indicator is pulled hi, so miomanager will need to be programmed to handle that.

Working towards HW-1938