### PR TITLE
Update the DTS to disable battery charging

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -309,6 +309,13 @@
         };
     };
 
+    // Disable the battery backup charging as we are using a coin cell.
+    i2c@7000d000 {
+        max77620: max77620@3c {
+            /delete-node/ backup-battery;
+        };
+    };
+
     //*********************************************************************
     // Fan Adjustments
     //*********************************************************************


### PR DESCRIPTION
We are using a non-recharable coin cell on the CTM, this prevents the
PMIC from trying to charge it.