### PR TITLE
Disable the DTS setting that enables the battery charge on the DCM

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -106,6 +106,13 @@
         status = "disabled";
     };
 
+    // Disable the battery backup charging as we are using a coin cell.
+    bpmp_i2c {
+        p2888_spmic: spmic@3c {
+            /delete-node/ backup-battery;
+        };
+    };
+
     //*********************************************************************
     // Serial UART Setup
     //*********************************************************************


### PR DESCRIPTION
The RTC has a non rechargable coin cell, this disables the PMIC battery
charging on the DCM.