### PR TITLE
Removing the AUX fan support on the CTM

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -255,7 +255,6 @@
     //		LM75 Temperature      0x49 (+53 Power Module)
     //		LM75 Temperature      0x4A (+12 Power Module)
     //		LM75 Temperature      0x4B (Ambient)
-    //		MAX6650 AUX Fan       0x1F (Aux Fan)
     // 		PCA9546 MUX           0x70 (Nano Internal Mux)
     i2c@7000c400 {
          status = "okay";
@@ -282,14 +281,6 @@
             status= "okay";
             compatible = "national,lm75";
             reg = <0x4b>;
-        };
-
-        max6650@1f {
-            reg = <0x1f>;
-            compatible = "maxim,max6650";
-            maxim,fan-microvolt = <12000000>;
-            maxim,fan-prescale = <4>;
-            maxim,fan-target-rpm = <0>;
         };
 
     };


### PR DESCRIPTION
We have decided to remove the AUX fan from the P3 CTM