### PR TITLE
Enable new DCM P3 test uart which is connected to the CTM

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -126,14 +126,14 @@
         status = "okay";
     };
 
-    // Xavier Module UART 0
+    // Xavier Module UART 1
     serial@3100000 {
         status = "disabled";
     };
 
-    // Xavier Module UART 1
+    // Xavier Module UART 2 - Connected to CTM
     serial@3110000 {
-        status = "disabled";
+        status = "okay";
     };
 
     // Xavier Module I2C-1 --> Tegra I2C2


### PR DESCRIPTION
Cherry picking the fix in the older kernel for the DCM test uart.