### PR TITLE
Enables SmartSense eeprom to DTS

### DIFF
--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
@@ -433,7 +433,7 @@
 	};
 	
 	i2c@c250000 {
-		status="disabled";
+		status="okay";
 	};
 	
 	cpus {


### PR DESCRIPTION
This is used during the Bootloader Upgrade process. I think it has
something to do with board information, which might have been flashed
in the factory. Either way, the nv_update_engine doesn't work without
this device present.

Found while working on HW-3165