### PR TITLE
Re-enabled the battery charging circuit on the DCM

### DIFF
--- a/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-spmic-p2888-0001.dtsi
+++ b/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-spmic-p2888-0001.dtsi
@@ -127,9 +127,9 @@
 
 			backup-battery {
 				backup-battery-charging-current = <100>;
-				backup-battery-charging-voltage = <3000000>;
+				backup-battery-charging-voltage = <2500000>;
 				backup-battery-output-resister = <100>;
-				status = "disabled";
+				status = "okay";
 			};
 
 			regulators {

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -106,12 +106,6 @@
         status = "disabled";
     };
 
-    // Disable the battery backup charging as we are using a coin cell.
-    bpmp_i2c {
-        p2888_spmic: spmic@3c {
-            /delete-node/ backup-battery;
-        };
-    };
 
     //*********************************************************************
     // Serial UART Setup


### PR DESCRIPTION
We need to re-enable the battery charging circuit in the DTS and then disable it once the OS is running.