### PR TITLE
battery charger. Cherry pick from royaloak-patches-l4t-r32.4 (#77)

### DIFF
--- a/drivers/mfd/max77620.c
+++ b/drivers/mfd/max77620.c
@@ -437,7 +437,17 @@ static int max77620_init_backup_battery_charging(struct max77620_chip *chip)
 			dev_err(dev, "Failed to update CNFGBBC: %d\n", ret);
 		return ret;
 	}
-
+	
+	/* Force disable of the battery charger, we are using a coin cell. */ 
+	if (!of_device_is_available(np)) {
+		ret = regmap_write(chip->rmap, MAX77620_REG_CNFGBBC, 0x8);
+		if (ret < 0){
+			dev_err(dev, "Reg 0x%02x write 0x8 failed, %d\n", MAX77620_REG_CNFGBBC, ret);
+			return ret;
+		}
+		return 0;
+	}
+	
 	ret = of_property_read_u32(np,
 			"backup-battery-charging-current", &pval);
 	if (ret < 0)

--- a/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
+++ b/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-royaloak-dcm.dts
@@ -106,10 +106,16 @@
         status = "disabled";
     };
 
-    // Disable the battery backup charging as we are using a coin cell.
+    // The status flag is not respected by the driver.
+    // This is disabled in the driver at runtime since we are using a coin cell.
     bpmp_i2c {
         p2888_spmic: spmic@3c {
-            /delete-node/ backup-battery;
+            backup-battery {
+                backup-battery-charging-current = <100>;
+                backup-battery-charging-voltage = <3000000>;
+                backup-battery-output-resister = <100>;
+                status = "disabled";
+            };
         };
     };
 


### PR DESCRIPTION
* Re-enables the battery charger in the DTS.

* Added a disable of the battery charging into the driver.
