### PR TITLE
Update to accelerometer bus for P4

### DIFF
--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -285,6 +285,13 @@
             reg = <0x4b>;
         };
 
+        iis2dh@18 {
+            compatible = "st,iis2dh_accel";
+            reg = <0x18>;
+            interrupt-parent = <&gpio>;
+            interrupts = <TEGRA_GPIO(J, 5) 0x01>;
+            interrupt-names = "INT1";
+        };
     };
 
     // Nano Module I2C-2 --> Tegra I2C3
@@ -303,7 +310,7 @@
             interrupt-names = "INT1";
         };
 
-        // Added in the P3 variant of the CTM
+        // LEGACY: Added in the P3 variant of the CTM
         iis2dh@18 {
             compatible = "st,iis2dh_accel";
             reg = <0x18>;
@@ -698,4 +705,3 @@
     };
 
 };
-


### PR DESCRIPTION
This changes the IIS2DH to use the I2C-1 bus to support P4 changes. 