### PR TITLE
Fixing an error with a goto statement that does not exist

### DIFF
--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -1578,7 +1578,7 @@ static int __init sc16is7xx_init(void)
 	ret = i2c_add_driver(&sc16is7xx_i2c_uart_driver);
 	if (ret < 0) {
 		pr_err("failed to init sc16is7xx i2c --> %d\n", ret);
-		goto err_i2c;
+		goto err_init;
 	}
 #endif
 
@@ -1586,16 +1586,15 @@ static int __init sc16is7xx_init(void)
 	ret = spi_register_driver(&sc16is7xx_spi_uart_driver);
 	if (ret < 0) {
 		pr_err("failed to init sc16is7xx spi --> %d\n", ret);
-		goto err_spi;
+		goto err_init;
 	}
 #endif
 	return ret;
 
-err_spi:
 #ifdef CONFIG_SERIAL_SC16IS7XX_I2C
 	i2c_del_driver(&sc16is7xx_i2c_uart_driver);
 #endif
-err_i2c:
+err_init:
 	uart_unregister_driver(&sc16is7xx_uart);
 	return ret;
 }


### PR DESCRIPTION
The new kernel errors now on these labels that are defined but never
called.