### PR TITLE
Removes unused reserved memory on SmartSense

### DIFF
--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
@@ -705,6 +705,17 @@
 		};
 	};	
 
+	reserved-memory {
+		fb0_reserved: fb0_carveout {
+			status = "disabled";
+		};
+		fb1_reserved: fb1_carveout {
+			status = "disabled";
+		};
+		fb2_reserved: fb2_carveout {
+			status = "disabled";
+		};
+	};
 };
 
 #if LINUX_VERSION >= 414


### PR DESCRIPTION
This is causing errors on the 2020.4 version of u-boot, as the
memory can't be reserved. This is probably because we remove a
bunch of other stuff related to display on the SmartSense because
we don't use the framebuffer. Disabling these nodes silences the
errors from u-boot.

Related to HW-3511