### PR TITLE
Macorke 2021 10 07 adds support for LIS2DTW12TR accelerometer device

### DIFF
--- a/drivers/iio/accel/st_acc33_core.c
+++ b/drivers/iio/accel/st_acc33_core.c
@@ -21,6 +21,7 @@
 
 #define REG_WHOAMI_ADDR			0x0f
 #define REG_WHOAMI_VAL			0x33
+#define REG_WHOAMI_VAL2			0x44
 
 #define REG_CTRL1_ADDR			0x20
 #define REG_CTRL1_ODR_MASK		GENMASK(7, 4)
@@ -410,9 +411,9 @@ static int st_acc33_check_whoami(struct st_acc33_hw *hw)
 		return err;
 	}
 
-	if (data != REG_WHOAMI_VAL) {
-		dev_err(hw->dev, "wrong whoami {%02x-%02x}\n",
-			data, REG_WHOAMI_VAL);
+	if (data != REG_WHOAMI_VAL && data != REG_WHOAMI_VAL2) {
+		dev_err(hw->dev, "wrong whoami {%02x-%02x or %02x}\n",
+			data, REG_WHOAMI_VAL,REG_WHOAMI_VAL2);
 		return -ENODEV;
 	}
 

--- a/drivers/iio/accel/st_acc33_core.c
+++ b/drivers/iio/accel/st_acc33_core.c
@@ -21,6 +21,8 @@
 
 #define REG_WHOAMI_ADDR			0x0f
 #define REG_WHOAMI_VAL			0x33
+
+// Support for LISDTW12TR
 #define REG_WHOAMI_VAL2			0x44
 
 #define REG_CTRL1_ADDR			0x20


### PR DESCRIPTION
Adds support for ST LIS2DTW12TR which has a different chip ID