### PR TITLE
Enables SS power monitor chips

### DIFF
--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
@@ -340,14 +340,7 @@
 			status = "disabled";
 		};
 
-		ina3221x@40 {
-			status = "disabled";
-		};
-
-		ina3221x@41 {
-			status = "disabled";
-		};
-
+		// Disabling 42 and 43 because they are only on the devkit.
 		ina3221x@42 {
 			status = "disabled";
 		};


### PR DESCRIPTION
These were disabled early in development of the SmartSense, along with
two other chips (comment added) which were only on the dev-kit (judging
from the schematic). It is assumed that they were disabled by accident.

Years later, access to these chips was requested by the CV team, so that
they could do the same power modelling that they did on the CTM. This
commit enables the sensors for them.

Fixes HW-3710