### PR TITLE
Kernel updates for the vGIC to speed up KVM

### DIFF
--- a/drivers/iommu/tegra-smmu.h
+++ b/drivers/iommu/tegra-smmu.h
@@ -288,7 +288,7 @@ extern void (*free_pdir)(struct smmu_as *as);
 int tegra_smmu_suspend(struct device *dev);
 int tegra_smmu_resume(struct device *dev);
 
-#ifdef CONFIG_TEGRA_HV_MANAGER
+#if defined(CONFIG_TEGRA_HV_MANAGER) && defined(CONFIG_TEGRA_IOMMU_SMMU_HV)
 extern int tegra_smmu_probe_hv(struct platform_device *pdev,
 					struct smmu_device *smmu);
 #else

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-royaloak-smartsense.dts
@@ -62,6 +62,21 @@
 		nvidia,tegra-joint_xpu_rail;
 	};
 
+    //***********************************************************************
+    // Update the vGIC to enable interrupt virtualization. This significatly
+    // impoves the interrupt handling performance in the virtual containers.
+    //
+    // See: https://github.com/BaoqianWang/VirtualizationOnJetsonTX2
+    //***********************************************************************
+
+    intc: interrupt-controller@3881000 {
+		reg = <0x0 0x03881000 0x0 0x00001000>,
+			  <0x0 0x03882000 0x0 0x00002000>,
+			  <0x0 0x03884000 0x0 0x00002000>,
+			  <0x0 0x03886000 0x0 0x00002000>;
+		interrupts = <GIC_PPI 9 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_HIGH)>;
+    };
+
 	aliases {
         mdio-gpio0 = &mdio1;
 	};

--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
+++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-p3448-0002-royaloak-ctm.dts
@@ -29,6 +29,21 @@
     compatible = "nvidia,jetson-nano", "nvidia,tegra210";
     nvidia,dtsfilename = __FILE__;
 
+    //***********************************************************************
+    // Update the vGIC to enable interrupt virtualization. This significatly
+    // impoves the interrupt handling performance in the virtual containers.
+    //
+    // See: https://github.com/lucaszanella/jetson_nano_kvm
+    //***********************************************************************
+
+    intc: interrupt-controller {
+        reg = <0x0 0x50041000 0x0 0x1000
+               0x0 0x50042000 0x0 0x2000
+               0x0 0x50044000 0x0 0x2000
+               0x0 0x50046000 0x0 0x2000>;
+        interrupts = <GIC_PPI 9 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_HIGH)>;
+    };
+
     //*********************************************************************
     // host1x Setup
     //*********************************************************************


### PR DESCRIPTION
We are in the process of enabling KVM on the RO targets, this requires enabling the virtual interrupt controller. We needed to make DTS changes in the CTM and Smart Sense to support this. The DCM already had the needed updates.

Partial Fix HW-3854

FYI @magmastonealex 